### PR TITLE
Fix cosine similarity zero division

### DIFF
--- a/QSub/semantic_spaces.py
+++ b/QSub/semantic_spaces.py
@@ -99,5 +99,12 @@ def word_cosine_similarity(v1, v2):
     La similitud coseno se define como el producto punto de los vectores dividido por el producto
     de sus magnitudes (normas).
     """
-    cos_sim = np.dot(v1, v2) / (np.linalg.norm(v1) * np.linalg.norm(v2))
+    norm1 = np.linalg.norm(v1)
+    norm2 = np.linalg.norm(v2)
+
+    # Evitar divisiones por cero si alguno de los vectores es nulo
+    if norm1 == 0 or norm2 == 0:
+        return 0.0
+
+    cos_sim = np.dot(v1, v2) / (norm1 * norm2)
     return cos_sim

--- a/tests/test_semantic_spaces.py
+++ b/tests/test_semantic_spaces.py
@@ -47,3 +47,13 @@ def test_lsa_corpus():
     assert type(resultado) == dict  # Comprueba que el resultado es un dict
     assert type(list(resultado.keys())[0]) == str  # Comprueba que las keys son strings
     assert type(list(resultado.values())[0]) == np.ndarray  # Comprueba que los values son ndarrays
+
+
+def test_word_cosine_similarity_zero_vector():
+    """La similitud coseno con un vector nulo debe ser 0."""
+    vec_a = np.array([1.0, 0.0, 0.0])
+    vec_b = np.array([0.0, 0.0, 0.0])
+
+    resultado = word_cosine_similarity(vec_a, vec_b)
+
+    assert resultado == 0.0


### PR DESCRIPTION
## Summary
- avoid zero division in `word_cosine_similarity`
- test cosine similarity with zero vector

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68400aa5b31c832eac37edd203617285