### PR TITLE
Add BERT semantic space support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The `QSub` Library is a Python package designed for creating and manipulating se
 
 ## Features
 
-- **Semantic Space Construction**: Utilize models like LSA (Latent Semantic Analysis), Word2Vec, and BERT to construct semantic spaces.
+- **Semantic Space Construction**: Utilize models like LSA (Latent Semantic Analysis), Word2Vec, and BERT to construct semantic spaces. New helper functions `get_word_vector_bert` and `get_bert_corpus` enable extraction of static embeddings from HuggingFace models.
 - **Contour Generation**: Generate semantic contours for given terms within these spaces.
 - **Subspace Creation**: Develop and manipulate subspaces based on semantic contours.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ cd QSub
 pip install .
 ```
 
+The BERT utilities require additional optional dependencies:
+
+```bash
+pip install transformers torch wordfreq
+```
+
 ## Usage
 
 QSub is in its first alpha version. You can find the first use example in our [Conceptual Contour Notebook](https://github.com/alejandrommingo/QSub/blob/main/notebooks/QSub_conceptual_contour_example.ipynb)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ python-Levenshtein==0.23.0
 tqdm==4.66.1
 scikit-learn==1.3.2
 pytest==7.4.3
+transformers==4.36.2
+torch==2.1.2
+wordfreq==2.5

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,9 @@ setup(
         'pytest',
         'tqdm',
         'python-Levenshtein',
-        'scikit-learn'
+        'scikit-learn',
+        'torch',
+        'wordfreq'
     ],
     include_package_data=True,  # Asegúrate de incluir esto
     package_data={

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,10 +23,18 @@ def stub_gallito(monkeypatch):
     def dummy_superterm(path, code, space):
         return np.random.rand(300), np.random.rand(10)
 
+    def dummy_word_vector_bert(word, model_name="bert-base-uncased"):
+        return np.random.rand(768)
+
+    def dummy_bert_corpus(language="en", model_name="bert-base-uncased", n_words=1000):
+        return {f"{language}_{i}": np.random.rand(768) for i in range(n_words)}
+
     monkeypatch.setattr(contours, "get_neighbors_matrix_gallito", dummy_neighbors)
     monkeypatch.setattr(contours, "get_superterm_gallito", dummy_superterm)
     monkeypatch.setattr(spaces, "get_word_vector_gallito", dummy_word_vector)
     monkeypatch.setattr(spaces, "get_lsa_corpus_gallito", dummy_lsa_corpus)
+    monkeypatch.setattr(spaces, "get_word_vector_bert", dummy_word_vector_bert)
+    monkeypatch.setattr(spaces, "get_bert_corpus", dummy_bert_corpus)
 
     # Stub wordcloud module if not installed
     if "wordcloud" not in sys.modules:

--- a/tests/test_semantic_spaces.py
+++ b/tests/test_semantic_spaces.py
@@ -63,3 +63,16 @@ def test_word_cosine_similarity_zero_vector():
     assert resultado == 0.0
 
 
+def test_word_vector_bert():
+    result = spaces.get_word_vector_bert("hello")
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (768,)
+
+
+def test_bert_corpus():
+    data = spaces.get_bert_corpus(language="en", n_words=5)
+    assert isinstance(data, dict)
+    assert len(data) == 5
+    assert isinstance(list(data.values())[0], np.ndarray)
+
+


### PR DESCRIPTION
## Summary
- add BERT utilities to `semantic_spaces`
- include BERT unit tests with stubs
- update dependencies and setup
- document BERT helpers in the README

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_68401a16dd68832e97c99a1040ed447d