### PR TITLE
Add BERT semantic space support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The `QSub` Library is a Python package designed for creating and manipulating se
 
 ## Features
 
-- **Semantic Space Construction**: Utilize models like LSA (Latent Semantic Analysis), Word2Vec, and BERT to construct semantic spaces.
+- **Semantic Space Construction**: Utilize models like LSA (Latent Semantic Analysis), Word2Vec, and BERT to construct semantic spaces. New helper functions `get_word_vector_bert` and `get_bert_corpus` enable extraction of static embeddings from HuggingFace models.
 - **Contour Generation**: Generate semantic contours for given terms within these spaces.
 - **Subspace Creation**: Develop and manipulate subspaces based on semantic contours.
 
@@ -18,6 +18,12 @@ To install QSub, run the following commands:
 git clone https://github.com/alejandrommingo/QSub.git
 cd QSub
 pip install .
+```
+
+The BERT utilities are optional. Install the extra dependencies with:
+
+```bash
+pip install .[bert]
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The `QSub` Library is a Python package designed for creating and manipulating se
 
 ## Features
 
-- **Semantic Space Construction**: Utilize models like LSA (Latent Semantic Analysis), Word2Vec, and BERT to construct semantic spaces. New helper functions `get_word_vector_bert` and `get_bert_corpus` enable extraction of static embeddings from HuggingFace models.
+- **Semantic Space Construction**: Utilize models like LSA (Latent Semantic Analysis), Word2Vec, and BERT to construct semantic spaces. Helper functions `get_word_vector_bert` and `get_bert_corpus` allow extracting vectors from any BERT layer or all layers.
 - **Contour Generation**: Generate semantic contours for given terms within these spaces.
 - **Subspace Creation**: Develop and manipulate subspaces based on semantic contours.
 
@@ -25,6 +25,10 @@ The BERT utilities are optional. Install the extra dependencies with:
 ```bash
 pip install .[bert]
 ```
+
+The BERT helper functions accept an ``output_layer`` argument to select a
+specific hidden layer (by index), ``"last"`` for the final layer (default) or
+``"all"`` to obtain a matrix with all layers.
 
 ## Usage
 

--- a/setup.py
+++ b/setup.py
@@ -10,13 +10,15 @@ setup(
         'requests',
         'matplotlib',
         'fuzzywuzzy',
-        'transformers',
-        'gensim',
         'pytest',
         'tqdm',
         'python-Levenshtein',
         'scikit-learn'
     ],
+    extras_require={
+        'bert': ['transformers', 'torch', 'wordfreq'],
+        'lsa': ['gensim']
+    },
     include_package_data=True,  # Asegúrate de incluir esto
     package_data={
         'QSub': ['resources/*']  # Incluye todos los archivos en la carpeta resources

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,10 +23,19 @@ def stub_gallito(monkeypatch):
     def dummy_superterm(path, code, space):
         return np.random.rand(300), np.random.rand(10)
 
-    def dummy_word_vector_bert(word, model_name="bert-base-uncased"):
+    def dummy_word_vector_bert(word, model_name="bert-base-uncased", output_layer="last"):
+        if output_layer == "all":
+            return np.random.rand(12, 768)
         return np.random.rand(768)
 
-    def dummy_bert_corpus(language="en", model_name="bert-base-uncased", n_words=1000):
+    def dummy_bert_corpus(
+        language="en",
+        model_name="bert-base-uncased",
+        n_words=1000,
+        output_layer="last",
+    ):
+        if output_layer == "all":
+            return {f"{language}_{i}": np.random.rand(12, 768) for i in range(n_words)}
         return {f"{language}_{i}": np.random.rand(768) for i in range(n_words)}
 
     monkeypatch.setattr(contours, "get_neighbors_matrix_gallito", dummy_neighbors)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,10 +23,18 @@ def stub_gallito(monkeypatch):
     def dummy_superterm(path, code, space):
         return np.random.rand(300), np.random.rand(10)
 
+    def dummy_word_vector_bert(word, model_name="bert-base-uncased"):
+        return np.random.rand(768)
+
+    def dummy_bert_corpus(language="en", model_name="bert-base-uncased", n_words=1000):
+        return {f"{language}_{i}": np.random.rand(768) for i in range(n_words)}
+
     monkeypatch.setattr(contours, "get_neighbors_matrix_gallito", dummy_neighbors)
     monkeypatch.setattr(contours, "get_superterm_gallito", dummy_superterm)
     monkeypatch.setattr(spaces, "get_word_vector_gallito", dummy_word_vector)
     monkeypatch.setattr(spaces, "get_lsa_corpus_gallito", dummy_lsa_corpus)
+    monkeypatch.setattr(spaces, "get_word_vector_bert", dummy_word_vector_bert)
+    monkeypatch.setattr(spaces, "get_bert_corpus", dummy_bert_corpus)
 
     # Stub wordcloud module if not installed
     if "wordcloud" not in sys.modules:

--- a/tests/test_semantic_spaces.py
+++ b/tests/test_semantic_spaces.py
@@ -63,3 +63,16 @@ def test_word_cosine_similarity_zero_vector():
     assert resultado == 0.0
 
 
+def test_word_vector_bert():
+    result = spaces.get_word_vector_bert("hello")
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (768,)
+
+
+def test_bert_corpus():
+    data = spaces.get_bert_corpus(language="en", n_words=5)
+    assert isinstance(data, dict)
+    assert len(data) == 5
+    assert isinstance(list(data.values())[0], np.ndarray)
+
+

--- a/tests/test_semantic_spaces.py
+++ b/tests/test_semantic_spaces.py
@@ -63,10 +63,16 @@ def test_word_cosine_similarity_zero_vector():
     assert resultado == 0.0
 
 
-def test_word_vector_bert():
+def test_word_vector_bert_last():
     result = spaces.get_word_vector_bert("hello")
     assert isinstance(result, np.ndarray)
     assert result.shape == (768,)
+
+
+def test_word_vector_bert_all_layers():
+    result = spaces.get_word_vector_bert("hello", output_layer="all")
+    assert isinstance(result, np.ndarray)
+    assert result.shape[1] == 768
 
 
 def test_bert_corpus():
@@ -74,5 +80,11 @@ def test_bert_corpus():
     assert isinstance(data, dict)
     assert len(data) == 5
     assert isinstance(list(data.values())[0], np.ndarray)
+
+
+def test_bert_corpus_all_layers():
+    data = spaces.get_bert_corpus(language="en", n_words=3, output_layer="all")
+    assert isinstance(list(data.values())[0], np.ndarray)
+    assert list(data.values())[0].shape[1] == 768
 
 


### PR DESCRIPTION
## Summary
- add BERT utilities to `semantic_spaces`
- include BERT unit tests with stubs
- update dependencies and setup
- document BERT helpers in the README
- make optional dependencies optional to avoid install errors

## Testing
- `pip install -e . --no-deps --no-use-pep517 --no-build-isolation`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68401a16dd68832e97c99a1040ed447d