### PR TITLE
Add multiple NLP models

### DIFF
--- a/QSub/semantic_spaces.py
+++ b/QSub/semantic_spaces.py
@@ -20,6 +20,16 @@ try:  # pragma: no cover - optional dependency
 except ImportError:  # pragma: no cover - optional dependency
     top_n_list = None
 
+try:  # pragma: no cover - optional dependency
+    import gensim.downloader as gensim_api
+except ImportError:  # pragma: no cover - optional dependency
+    gensim_api = None
+
+try:  # pragma: no cover - optional dependency
+    from allennlp.commands.elmo import ElmoEmbedder
+except ImportError:  # pragma: no cover - optional dependency
+    ElmoEmbedder = None
+
 #############################################
 ## GALLITO BASED SEMANTIC SPACE OPERATIONS ##
 #############################################
@@ -99,6 +109,10 @@ def get_lsa_corpus_gallito(terms_file, gallito_code, space_name):
 #############################################
 
 _bert_models = {}
+_gpt2_models = {}
+_w2v_models = {}
+_glove_models = {}
+_elmo_models = {}
 
 def _load_bert(model_name):
     """Load tokenizer and model for ``model_name`` with hidden states."""
@@ -178,6 +192,253 @@ def get_bert_corpus(
             corpus_dict[term] = np.array(vector)
 
     return corpus_dict
+
+#############################################
+## GPT2 BASED SEMANTIC SPACE OPERATIONS    ##
+#############################################
+
+def _load_gpt2(model_name):
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModel.from_pretrained(model_name, output_hidden_states=True)
+    model.eval()
+    return tokenizer, model
+
+
+def get_word_vector_gpt2(word, model_name="gpt2", output_layer="last"):
+    """Return GPT2 embeddings for a given word.
+
+    Parameters are analogous to :func:`get_word_vector_bert`.
+    """
+
+    if AutoTokenizer is None or AutoModel is None or torch is None:
+        raise ImportError(
+            "transformers and torch must be installed to use get_word_vector_gpt2"
+        )
+
+    if model_name not in _gpt2_models:
+        _gpt2_models[model_name] = _load_gpt2(model_name)
+    tokenizer, model = _gpt2_models[model_name]
+    inputs = tokenizer(word, return_tensors="pt")
+    with torch.no_grad():
+        outputs = model(**inputs)
+
+    if output_layer == "last":
+        vector = outputs.last_hidden_state.mean(dim=1).squeeze()
+        return vector.numpy()
+
+    if output_layer == "all":
+        hidden = [h.mean(dim=1).squeeze().numpy() for h in outputs.hidden_states]
+        return np.stack(hidden)
+
+    if isinstance(output_layer, int):
+        hidden_states = outputs.hidden_states
+        if output_layer < 0 or output_layer >= len(hidden_states):
+            raise ValueError("output_layer out of range")
+        vector = hidden_states[output_layer].mean(dim=1).squeeze()
+        return vector.numpy()
+
+    raise ValueError("output_layer must be 'last', 'all', or an integer index")
+
+
+def get_gpt2_corpus(
+    language="en",
+    model_name="gpt2",
+    n_words=1000,
+    output_layer="last",
+):
+    """Return a dictionary with GPT2 vectors of the most frequent words."""
+
+    if top_n_list is None:
+        raise ImportError("wordfreq must be installed to use get_gpt2_corpus")
+    words = top_n_list(language, n_words)
+
+    def get_vector(term):
+        return term, get_word_vector_gpt2(term, model_name, output_layer)
+
+    corpus_dict = {}
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        for term, vector in tqdm(executor.map(get_vector, words),
+                                 total=len(words),
+                                 desc="Procesando términos"):
+            corpus_dict[term] = np.array(vector)
+
+    return corpus_dict
+
+#############################################
+## WORD2VEC AND GLOVE OPERATIONS          ##
+#############################################
+
+def _load_word2vec(model_name):
+    return gensim_api.load(model_name)
+
+
+def get_word_vector_word2vec(word, model_name="word2vec-google-news-300"):
+    """Return Word2Vec embeddings for ``word`` from ``model_name``."""
+
+    if gensim_api is None:
+        raise ImportError("gensim must be installed to use get_word_vector_word2vec")
+
+    if model_name not in _w2v_models:
+        _w2v_models[model_name] = _load_word2vec(model_name)
+    model = _w2v_models[model_name]
+    return model[word]
+
+
+def get_word2vec_corpus(
+    language="en",
+    model_name="word2vec-google-news-300",
+    n_words=1000,
+):
+    """Return a dictionary with Word2Vec vectors of the most frequent words."""
+
+    if gensim_api is None:
+        raise ImportError("gensim must be installed to use get_word2vec_corpus")
+    if top_n_list is None:
+        raise ImportError("wordfreq must be installed to use get_word2vec_corpus")
+
+    words = top_n_list(language, n_words)
+
+    def get_vector(term):
+        try:
+            return term, get_word_vector_word2vec(term, model_name)
+        except KeyError:
+            return term, None
+
+    corpus_dict = {}
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        for term, vector in tqdm(executor.map(get_vector, words),
+                                 total=len(words),
+                                 desc="Procesando términos"):
+            if vector is not None:
+                corpus_dict[term] = np.array(vector)
+
+    return corpus_dict
+
+
+def _load_glove(model_name):
+    return gensim_api.load(model_name)
+
+
+def get_word_vector_glove(word, model_name="glove-wiki-gigaword-300"):
+    """Return GloVe embeddings for ``word`` from ``model_name``."""
+
+    if gensim_api is None:
+        raise ImportError("gensim must be installed to use get_word_vector_glove")
+
+    if model_name not in _glove_models:
+        _glove_models[model_name] = _load_glove(model_name)
+    model = _glove_models[model_name]
+    return model[word]
+
+
+def get_glove_corpus(
+    language="en",
+    model_name="glove-wiki-gigaword-300",
+    n_words=1000,
+):
+    """Return a dictionary with GloVe vectors of the most frequent words."""
+
+    if gensim_api is None:
+        raise ImportError("gensim must be installed to use get_glove_corpus")
+    if top_n_list is None:
+        raise ImportError("wordfreq must be installed to use get_glove_corpus")
+
+    words = top_n_list(language, n_words)
+
+    def get_vector(term):
+        try:
+            return term, get_word_vector_glove(term, model_name)
+        except KeyError:
+            return term, None
+
+    corpus_dict = {}
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        for term, vector in tqdm(executor.map(get_vector, words),
+                                 total=len(words),
+                                 desc="Procesando términos"):
+            if vector is not None:
+                corpus_dict[term] = np.array(vector)
+
+    return corpus_dict
+
+#############################################
+## ELMO BASED SEMANTIC SPACE OPERATIONS   ##
+#############################################
+
+def _load_elmo(model_name="small"):
+    return ElmoEmbedder(model_name=model_name)
+
+
+def get_word_vector_elmo(word, model_name="small", output_layer="average"):
+    """Return ELMo embeddings for a given word.
+
+    ``output_layer`` can be ``"average"`` (default), ``"all"`` or the index of a
+    specific layer.
+    """
+
+    if ElmoEmbedder is None:
+        raise ImportError("allennlp must be installed to use get_word_vector_elmo")
+
+    if model_name not in _elmo_models:
+        _elmo_models[model_name] = _load_elmo(model_name)
+    embedder = _elmo_models[model_name]
+    vectors = embedder.embed_sentence([word])  # (layers, 1, dim)
+
+    if output_layer == "average":
+        return vectors.mean(axis=0).squeeze()
+
+    if output_layer == "all":
+        return vectors.squeeze()
+
+    if isinstance(output_layer, int):
+        if output_layer < 0 or output_layer >= vectors.shape[0]:
+            raise ValueError("output_layer out of range")
+        return vectors[output_layer, 0, :]
+
+    raise ValueError("output_layer must be 'average', 'all', or an integer index")
+
+
+def get_elmo_corpus(
+    language="en",
+    model_name="small",
+    n_words=1000,
+    output_layer="average",
+):
+    """Return a dictionary with ELMo vectors of the most frequent words."""
+
+    if top_n_list is None:
+        raise ImportError("wordfreq must be installed to use get_elmo_corpus")
+    words = top_n_list(language, n_words)
+
+    def get_vector(term):
+        return term, get_word_vector_elmo(term, model_name, output_layer)
+
+    corpus_dict = {}
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        for term, vector in tqdm(executor.map(get_vector, words),
+                                 total=len(words),
+                                 desc="Procesando términos"):
+            corpus_dict[term] = np.array(vector)
+
+    return corpus_dict
+
+#############################################
+## DISTILBERT BASED SEMANTIC SPACE OPS    ##
+#############################################
+
+def get_word_vector_distilbert(word, model_name="distilbert-base-uncased", output_layer="last"):
+    """Wrapper around :func:`get_word_vector_bert` for DistilBERT."""
+    return get_word_vector_bert(word, model_name=model_name, output_layer=output_layer)
+
+
+def get_distilbert_corpus(
+    language="en",
+    model_name="distilbert-base-uncased",
+    n_words=1000,
+    output_layer="last",
+):
+    """Wrapper around :func:`get_bert_corpus` for DistilBERT."""
+    return get_bert_corpus(language, model_name=model_name, n_words=n_words, output_layer=output_layer)
 
 #######################################
 ## GENERAL SEMANTIC SPACE OPERATIONS ##

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The `QSub` Library is a Python package designed for creating and manipulating se
 
 ## Features
 
-- **Semantic Space Construction**: Utilize models like LSA (Latent Semantic Analysis), Word2Vec, and BERT to construct semantic spaces. Helper functions `get_word_vector_bert` and `get_bert_corpus` allow extracting vectors from any BERT layer or all layers.
+- **Semantic Space Construction**: Utilize models like LSA (Latent Semantic Analysis), Word2Vec, GloVe, GPT2, ELMo and BERT variants (including DistilBERT) to construct semantic spaces. Helper functions allow extracting vectors from selected layers when supported.
 - **Contour Generation**: Generate semantic contours for given terms within these spaces.
 - **Subspace Creation**: Develop and manipulate subspaces based on semantic contours.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,44 @@ def stub_gallito(monkeypatch):
             return np.random.rand(12, 768)
         return np.random.rand(768)
 
+    def dummy_word_vector_gpt2(word, model_name="gpt2", output_layer="last"):
+        if output_layer == "all":
+            return np.random.rand(12, 768)
+        return np.random.rand(768)
+
+    def dummy_gpt2_corpus(language="en", model_name="gpt2", n_words=1000, output_layer="last"):
+        if output_layer == "all":
+            return {f"{language}_{i}": np.random.rand(12, 768) for i in range(n_words)}
+        return {f"{language}_{i}": np.random.rand(768) for i in range(n_words)}
+
+    def dummy_word_vector_word2vec(word, model_name="word2vec-google-news-300"):
+        return np.random.rand(300)
+
+    def dummy_word2vec_corpus(language="en", model_name="word2vec-google-news-300", n_words=1000):
+        return {f"{language}_{i}": np.random.rand(300) for i in range(n_words)}
+
+    def dummy_word_vector_glove(word, model_name="glove-wiki-gigaword-300"):
+        return np.random.rand(300)
+
+    def dummy_glove_corpus(language="en", model_name="glove-wiki-gigaword-300", n_words=1000):
+        return {f"{language}_{i}": np.random.rand(300) for i in range(n_words)}
+
+    def dummy_word_vector_elmo(word, model_name="small", output_layer="average"):
+        if output_layer == "all":
+            return np.random.rand(3, 1024)
+        return np.random.rand(1024)
+
+    def dummy_elmo_corpus(language="en", model_name="small", n_words=1000, output_layer="average"):
+        if output_layer == "all":
+            return {f"{language}_{i}": np.random.rand(3, 1024) for i in range(n_words)}
+        return {f"{language}_{i}": np.random.rand(1024) for i in range(n_words)}
+
+    def dummy_word_vector_distilbert(word, model_name="distilbert-base-uncased", output_layer="last"):
+        return np.random.rand(768)
+
+    def dummy_distilbert_corpus(language="en", model_name="distilbert-base-uncased", n_words=1000, output_layer="last"):
+        return {f"{language}_{i}": np.random.rand(768) for i in range(n_words)}
+
     def dummy_bert_corpus(
         language="en",
         model_name="bert-base-uncased",
@@ -44,6 +82,16 @@ def stub_gallito(monkeypatch):
     monkeypatch.setattr(spaces, "get_lsa_corpus_gallito", dummy_lsa_corpus)
     monkeypatch.setattr(spaces, "get_word_vector_bert", dummy_word_vector_bert)
     monkeypatch.setattr(spaces, "get_bert_corpus", dummy_bert_corpus)
+    monkeypatch.setattr(spaces, "get_word_vector_gpt2", dummy_word_vector_gpt2)
+    monkeypatch.setattr(spaces, "get_gpt2_corpus", dummy_gpt2_corpus)
+    monkeypatch.setattr(spaces, "get_word_vector_word2vec", dummy_word_vector_word2vec)
+    monkeypatch.setattr(spaces, "get_word2vec_corpus", dummy_word2vec_corpus)
+    monkeypatch.setattr(spaces, "get_word_vector_glove", dummy_word_vector_glove)
+    monkeypatch.setattr(spaces, "get_glove_corpus", dummy_glove_corpus)
+    monkeypatch.setattr(spaces, "get_word_vector_elmo", dummy_word_vector_elmo)
+    monkeypatch.setattr(spaces, "get_elmo_corpus", dummy_elmo_corpus)
+    monkeypatch.setattr(spaces, "get_word_vector_distilbert", dummy_word_vector_distilbert)
+    monkeypatch.setattr(spaces, "get_distilbert_corpus", dummy_distilbert_corpus)
 
     # Stub wordcloud module if not installed
     if "wordcloud" not in sys.modules:

--- a/tests/test_semantic_spaces.py
+++ b/tests/test_semantic_spaces.py
@@ -85,3 +85,54 @@ def test_bert_corpus_all_layers():
     assert isinstance(list(data.values())[0], np.ndarray)
     assert list(data.values())[0].shape[1] == 768
 
+
+def test_word_vector_gpt2_last():
+    result = spaces.get_word_vector_gpt2("hello")
+    assert isinstance(result, np.ndarray)
+
+
+def test_gpt2_corpus():
+    data = spaces.get_gpt2_corpus(language="en", n_words=2)
+    assert isinstance(data, dict)
+    assert len(data) == 2
+
+
+def test_word_vector_word2vec():
+    result = spaces.get_word_vector_word2vec("hello")
+    assert isinstance(result, np.ndarray)
+
+
+def test_word2vec_corpus():
+    data = spaces.get_word2vec_corpus(language="en", n_words=2)
+    assert isinstance(data, dict)
+
+
+def test_word_vector_glove():
+    result = spaces.get_word_vector_glove("hello")
+    assert isinstance(result, np.ndarray)
+
+
+def test_glove_corpus():
+    data = spaces.get_glove_corpus(language="en", n_words=2)
+    assert isinstance(data, dict)
+
+
+def test_word_vector_elmo_average():
+    result = spaces.get_word_vector_elmo("hello")
+    assert isinstance(result, np.ndarray)
+
+
+def test_elmo_corpus():
+    data = spaces.get_elmo_corpus(language="en", n_words=2)
+    assert isinstance(data, dict)
+
+
+def test_word_vector_distilbert():
+    result = spaces.get_word_vector_distilbert("hello")
+    assert isinstance(result, np.ndarray)
+
+
+def test_distilbert_corpus():
+    data = spaces.get_distilbert_corpus(language="en", n_words=2)
+    assert isinstance(data, dict)
+


### PR DESCRIPTION
## Summary
- support GPT2, Word2Vec, GloVe, ELMo and DistilBERT in semantic spaces
- expand stubs and tests for the new models
- mention the extra models in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684199909568832e9c3e4895037938a7